### PR TITLE
Some sites incorrectly treated as SVG which scrolls immediately to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,16 @@ For developers
 
 Test these sites:
 
-* `https://easywebsoc.td.com/waw/idp/login.htm?execution=e1s1`
-* `9to5mac.com`
-* `www.willhaben.at`
-* `http://www.wind.it/it/privati/`
-* `http://www.opengl.org/sdk/docs/man/xhtml/glDrawElements.xml`
-* `https://www.opengl.org/sdk/docs/man/html/glDrawElements.xhtml`
-* `https://twitter.com/amcharts`
-* `http://addepar.github.io/ember-table/#/ember-table/simple`
-* `http://blog.dogecoin.com/`
-* `https://plus.google.com/`
-* `https://duckduckgo.com/?q=test&ia=meanings`
+* <https://easyweb.td.com/waw/idp/login.htm?execution=e1s1>
+* <http://9to5mac.com/>
+* <https://www.willhaben.at/>
+* <http://www.wind.it/it/privati/>
+* <https://www.opengl.org/sdk/docs/man/html/glDrawElements.xhtml>
+* <https://twitter.com/amcharts>
+* <http://addepar.github.io/ember-table/>
+* <https://plus.google.com/>
+* <https://duckduckgo.com/?q=test&ia=meanings>
+* <http://fivethirtyeight.com/>
 
 TODO
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "AutoScroll",
-  "version": "4.6",
+  "version": "4.7",
   "description": "This extension adds customizable autoscroll support to Chrome.",
   "minimum_chrome_version": "29",
   "icons": {
@@ -22,6 +22,6 @@
     "all_frames": false,
     "js": [ "data/defaults.js", "data/AutoScroll.js" ],
     "matches": [ "<all_urls>" ],
-    "run_at": "document_start"
+    "run_at": "document_end"
   }]
 }


### PR DESCRIPTION
On sites like <http://www.fivethirtyeight.com>, clicking the scroll wheel resets the `scrollTop` to the top of the page minus any margins (`32px` from the top, in the fivethirtyeight example). This is because the `bodyNode` is incorrectly set to the document node after the SVG test incorrectly assumes the document is SVG. When we change the manifest to load this extension on document_end, the DOM has had a chance to be built, so a `document.body` is correctly detected.