### PR TITLE
nothing happens on pages with short body elements

### DIFF
--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -472,8 +472,8 @@ chrome.storage.local.get(defaults, function (options) {
       if (((e.button === 1 && options["middleClick"]) ||
            (e.button === 0 && (e.ctrlKey || e.metaKey) && options["ctrlClick"])) &&
           // TODO what about using middle click on the scrollbar of a non-<html> element ?
-          e.clientX < window.innerWidth &&
-          e.clientY < window.innerHeight &&
+          e.clientX < htmlNode.clientWidth &&
+          e.clientY < htmlNode.clientHeight &&
           isValid(e.target)) {
 
         var elem = findScroll(e.target)

--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -471,6 +471,7 @@ chrome.storage.local.get(defaults, function (options) {
     } else {
       if (((e.button === 1 && options["middleClick"]) ||
            (e.button === 0 && (e.ctrlKey || e.metaKey) && options["ctrlClick"])) &&
+          // Make sure the click is not on a scrollbar
           // TODO what about using middle click on the scrollbar of a non-<html> element ?
           e.clientX < htmlNode.clientWidth &&
           e.clientY < htmlNode.clientHeight &&

--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -472,8 +472,8 @@ chrome.storage.local.get(defaults, function (options) {
       if (((e.button === 1 && options["middleClick"]) ||
            (e.button === 0 && (e.ctrlKey || e.metaKey) && options["ctrlClick"])) &&
           // TODO what about using middle click on the scrollbar of a non-<html> element ?
-          e.clientX < bodyNode.clientWidth &&
-          e.clientY < bodyNode.clientHeight &&
+          e.clientX < htmlNode.clientWidth &&
+          e.clientY < htmlNode.clientHeight &&
           isValid(e.target)) {
 
         var elem = findScroll(e.target)

--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -472,8 +472,8 @@ chrome.storage.local.get(defaults, function (options) {
       if (((e.button === 1 && options["middleClick"]) ||
            (e.button === 0 && (e.ctrlKey || e.metaKey) && options["ctrlClick"])) &&
           // TODO what about using middle click on the scrollbar of a non-<html> element ?
-          e.clientX < htmlNode.clientWidth &&
-          e.clientY < htmlNode.clientHeight &&
+          e.clientX < window.innerWidth &&
+          e.clientY < window.innerHeight &&
           isValid(e.target)) {
 
         var elem = findScroll(e.target)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "AutoScroll",
-  "version": "4.7",
+  "version": "4.8",
   "description": "This extension adds customizable autoscroll support to Chrome.",
   "minimum_chrome_version": "29",
   "icons": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "AutoScroll",
-  "version": "4.8",
+  "version": "4.7",
   "description": "This extension adds customizable autoscroll support to Chrome.",
   "minimum_chrome_version": "29",
   "icons": {


### PR DESCRIPTION
Sometimes, the `body` element's `clientHeight` can be very short despite the content inside being long. In those cases, scrolling comes from the `htmlNode` instead. For example, <https://www.washingtonpost.com/news/wonk/wp/2016/01/20/we-have-a-q-tips-problem/>. Here, the body element is only `150px` tall despite the window being much taller.

In this PR, we fix that by using the `window` object for viewport checking instead. I'm leaving version updating to you so my other PR doesn't cause a conflict. I've tested this against standard sites and an SVG site, namely <https://upload.wikimedia.org/wikipedia/commons/6/6c/Trajans-Column-lower-animated.svg>, which you may also want to add to the `README`.