### PR TITLE
Use attachShadow API if available

### DIFF
--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -167,10 +167,12 @@ chrome.storage.local.get(defaults, function (options) {
 
   // TODO replace with `attachShadow` once it's supported in Chrome
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/createShadowRoot
-  var shadow = (outer.createShadowRoot
-                 ? outer.createShadowRoot()
-                 // TODO hack for Chrome 29 to 34, remove this later
-                 : outer.webkitCreateShadowRoot())
+  var shadow = outer.attachShadow
+    ? outer.attachShadow({ mode: "closed" })
+    : outer.createShadowRoot
+      ? outer.createShadowRoot()
+      // TODO hack for Chrome 29 to 34, remove this later
+      : outer.webkitCreateShadowRoot()
 
   // This is needed to make AutoScroll work in SVG documents
   var inner = document.createElementNS(htmlNamespace, "div")

--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -163,8 +163,7 @@ chrome.storage.local.get(defaults, function (options) {
 
 
   // This is needed to make AutoScroll work in SVG documents
-  var outer = document.createElementNS(htmlNamespace, "AutoScroll")
-
+  var outer = document.createElementNS(htmlNamespace, "auto-scroll")
 
   // TODO replace with `attachShadow` once it's supported in Chrome
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/createShadowRoot
@@ -187,7 +186,6 @@ chrome.storage.local.get(defaults, function (options) {
   inner.style.setProperty("background-repeat", "no-repeat")
 
   shadow.appendChild(inner)
-
 
   function mousewheel(event) {
     // TODO is this a good idea ?


### PR DESCRIPTION
Fixes #21. The custom element name change is necessary because `attachShadow` doesn't work if the element name is invalid (see https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow and https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name).

I left the `webkitCreateShadowRoot` code in to keep the PR focused on the issue, but to be honest it can probably be taken out now. There can't be many people out there who are still using <= v34.