### PR TITLE
Fixed activating on editable textareas/inputs

### DIFF
--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -295,12 +295,13 @@ chrome.storage.local.get(defaults, function (options) {
     inner.style.removeProperty("display")
   }
 
-  const anchor_tags = new Set(['a', 'area']);
-  const input_tags = new Set(['input', 'textarea']);
+
   function isInvalid(elem) {
     return elem.isContentEditable ||
-           (anchor_tags.has(elem.localName) && elem.href) ||
-           (input_tags.has(elem.localName) && isEditableText(elem));
+           (elem.localName === "a" && elem.href) ||
+           (elem.localName === "area" && elem.href) ||
+           (elem.localName === "textarea") && isEditableText(elem) ||
+           (elem.localName === "input") && isEditableText(elem);
   }
 
   function isEditableText(elem) {

--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -300,8 +300,8 @@ chrome.storage.local.get(defaults, function (options) {
     return elem.isContentEditable ||
            (elem.localName === "a" && elem.href) ||
            (elem.localName === "area" && elem.href) ||
-           (elem.localName === "textarea") && isEditableText(elem) ||
-           (elem.localName === "input") && isEditableText(elem);
+           (elem.localName === "textarea" && isEditableText(elem)) ||
+           (elem.localName === "input" && isEditableText(elem));
   }
 
   function isEditableText(elem) {

--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -295,8 +295,8 @@ chrome.storage.local.get(defaults, function (options) {
     inner.style.removeProperty("display")
   }
 
-  const anchor_tags = new Set('a', 'area');
-  const input_tags = new Set('input', 'textarea');
+  const anchor_tags = new Set(['a', 'area']);
+  const input_tags = new Set(['input', 'textarea']);
   function isInvalid(elem) {
     return elem.isContentEditable ||
            (anchor_tags.has(elem.localName) && elem.href) ||


### PR DESCRIPTION
The set was interpreting the strings as the set of objects, so by default was using the first several characters of the first parameter as individual items in the set.

The first parameter for 'anchor_tags' was 'a', which is a single letter, and that worked! The 'area' parameter was unused, though.

The first parameter for 'input_tags', however, was 'input' - which was causing the set to contain just ['i', 'n', 'p', 'u', 't'].

I noticed this after I decided I'd try swapping their order, and then tried inspecting the set to see if the order was swapped... And was surprised to see the set only contained ['t', 'e', 'x', 't', 'a']. Didn't even spell out the whole word.

Looking at the docs on MDN led me to finding out that you have to pass in an array, rather than have each item be a parameter.