### PR TITLE
Add ability to disable on Windows platform

### DIFF
--- a/src/data/AutoScroll.js
+++ b/src/data/AutoScroll.js
@@ -480,7 +480,10 @@ chrome.storage.local.get(defaults, function (options) {
 
   htmlNode.appendChild(outer)
 
+    
   addEventListener("mousedown", function (e) {
+    if (navigator.platform == "Win32" && options["disableOnWin32"] == true) return;
+    
     if (state.scrolling) {
       stopEvent(e, true)
 

--- a/src/data/defaults.js
+++ b/src/data/defaults.js
@@ -11,5 +11,6 @@ var defaults = {
   capSpeed: "",
   shouldCap: false,
   ctrlClick: true,
-  middleClick: true
+  middleClick: true,
+  disableOnWin32: true
 }

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -176,6 +176,11 @@ require(["lib/chrome-extension/options", "lib/util/cell", "lib/util/ui"], functi
           default: defaults["scrollOnLinks"],
           text: "Scroll when clicking on a link or textarea"
         })
+        
+        options.checkbox(e, opts["disableOnWin32"], {
+          default: defaults["disableOnWin32"],
+          text: "Disable on Windows platform"
+        })
       })
     })
   })


### PR DESCRIPTION
The vanilla version changed the scroll behavior on Windows platform, make it feels weird especially on Microsoft Edge. So I added a toggle to disable itself on Windows.